### PR TITLE
Changed Path determination in ValidatePath

### DIFF
--- a/Loader/ParallaxSource.cs
+++ b/Loader/ParallaxSource.cs
@@ -2237,19 +2237,10 @@ namespace ParallaxShader
         }
         public void ValidatePath(string path, string name)
         {
-            string actualPath = "";
-            if (Application.platform == RuntimePlatform.OSXPlayer)
-            {
-                actualPath = Application.dataPath.Remove(Application.dataPath.Length - 16, 16) + "GameData/" + path;
-            }
-            else if (Application.platform == RuntimePlatform.WindowsPlayer)
-            {
-                actualPath = Application.dataPath.Remove(Application.dataPath.Length - 12, 12) + "GameData/" + path;
-            }
-            else
-            {
-                actualPath = Application.dataPath.Remove(Application.dataPath.Length - 16, 16) + "GameData/" + path;
-            }
+            string actualPath = Application.dataPath;
+            int lastDash = actualPath.LastIndexOf('/');
+            actualPath = actualPath.Remove(lastDash + 1) + "GameData/" + path;
+            
             Log("Validating " + actualPath);
             bool fileExists = File.Exists(actualPath);
             if (fileExists)


### PR DESCRIPTION
While running Parallax on my KSP-Linux install, I noticed that the texture paths were wrong.
I saw a forum post of yours that you were planning to change it, as others were having similar issues.
For example Issue #19. 
This change should make it more portable, as the path is not determined on a case by case basis.
