### PR TITLE
Update SubdivisionPQSMod.cs

### DIFF
--- a/SubdivisionPQSMod.cs
+++ b/SubdivisionPQSMod.cs
@@ -235,7 +235,7 @@ namespace PQSModExpansion
             //
             //}
             //SUBDIVISION MOD
-            if (quad is null || quad.mesh == null)
+            if (quad == null || quad.mesh == null)
             {
                 Debug.Log("Quad is null and has been caught. Distance to vessel is: ");
                 try
@@ -247,26 +247,19 @@ namespace PQSModExpansion
                     Debug.Log("Unable to get distance to vessel");
                 }
             }
-            try
+            else if (quad.subdivision == FlightGlobals.currentMainBody.pqsController.maxLevel && HighLogic.LoadedScene == GameScenes.FLIGHT)
             {
-                if (quad.subdivision == FlightGlobals.currentMainBody.pqsController.maxLevel && HighLogic.LoadedScene == GameScenes.FLIGHT)
-                {
-                    Debug.Log("Mask: " + LayerMask.GetMask());
-                    quad.gameObject.AddComponent<QuadMeshes>();
-                    quad.gameObject.GetComponent<QuadMeshes>().quad = quad;
-                    quad.gameObject.GetComponent<QuadMeshes>().subdivisionLevel = (int)(subdivisionLevel * ParallaxSettings.tessMult);
-                    quad.gameObject.GetComponent<QuadMeshes>().overrideDistLimit = overrideDistLimit;
-                    quad.gameObject.GetComponent<QuadMeshes>().customDistLimit = customDistLimit;
-                }
-            }
-            catch (Exception e)
-            {
-                Debug.Log("[Parallax] Subdivision Error:\n" + e.ToString());
+                Debug.Log("Mask: " + LayerMask.GetMask());
+                quad.gameObject.AddComponent<QuadMeshes>();
+                quad.gameObject.GetComponent<QuadMeshes>().quad = quad;
+                quad.gameObject.GetComponent<QuadMeshes>().subdivisionLevel = (int)(subdivisionLevel * ParallaxSettings.tessMult);
+                quad.gameObject.GetComponent<QuadMeshes>().overrideDistLimit = overrideDistLimit;
+                quad.gameObject.GetComponent<QuadMeshes>().customDistLimit = customDistLimit;
             }
 
             //ADAPTIVE PARALLAX
 
-            try
+            if (quad)
             {
                 double highPoint = 0;
                 double lowPoint = 0;
@@ -360,10 +353,6 @@ namespace PQSModExpansion
                     }
                 }
 
-            }
-            catch (Exception e)
-            {
-                Debug.Log("[Parallax] Subdivision Error (Adaptive Parallax):\n" + e.ToString());
             }
 
         }
@@ -509,7 +498,7 @@ namespace PQSModExpansion
     {
         public void Start()
         {
-            GrassMaterial.grassMaterial = new Material(ParallaxLoader.GetShader("Custom/Grass"));
+            /*GrassMaterial.grassMaterial = new Material(ParallaxLoader.GetShader("Custom/Grass"));
             GrassMaterial.grassMaterial.SetColor("_TopColor", new Color(0.8396226f, 0.5663492f, 0.7778036f));
             GrassMaterial.grassMaterial.SetColor("_BottomColor", new Color(0.245283f, 0.03818085f, 0.182885f));
             GrassMaterial.grassMaterial.SetFloat("_BladeWidth", 10);
@@ -521,7 +510,7 @@ namespace PQSModExpansion
             GrassMaterial.grassMaterial.SetFloat("_BlendRotationRandom", 0);
             GrassMaterial.grassMaterial.SetFloat("_WindStrength", 1);
             GrassMaterial.grassMaterial.SetFloat("_TranslucentGain", 0.315f);
-            GrassMaterial.grassMaterial.SetFloat("_TessellationEdgeLength", 6.6f);
+            GrassMaterial.grassMaterial.SetFloat("_TessellationEdgeLength", 6.6f);*/
         }
     }
     public static class MeshHelper
@@ -1103,8 +1092,9 @@ namespace PQSModExpansion
         }
         public void ChangeSpaceCenterColor()
         {
-            Debug.Log("Home planet detected as " + FlightGlobals.GetHomeBody().displayName);
-            if (FlightGlobals.GetHomeBody().displayName == "Kerbin^N")
+            CelestialBody homebody = Utility.FindBody(PSystemManager.Instance.systemPrefab.rootBody, "Kerbin").celestialBody;
+            Debug.Log("Home planet detected as " + homebody.displayName);
+            if (homebody.displayName == "Kerbin^N")
             {
                 CelestialBody kerbin = FlightGlobals.GetHomeBody();
                 PQSCity ksc = kerbin.pqsController.GetComponentsInChildren<PQSCity>(true).First(m => m.name == "KSC");

--- a/SubdivisionPQSMod.cs
+++ b/SubdivisionPQSMod.cs
@@ -235,32 +235,32 @@ namespace PQSModExpansion
             //
             //}
             //SUBDIVISION MOD
-            if (quad == null || quad.mesh == null)
+            if ((quad) && (FlightGlobals.currentMainBody))
             {
-                Debug.Log("Quad is null and has been caught. Distance to vessel is: ");
-                try
+                if (quad.mesh == null)
                 {
-                    Debug.Log(quad.transform.position - FlightGlobals.ActiveVessel.transform.position);
+                    Debug.Log("Quad is null and has been caught. Distance to vessel is: ");
+                    try
+                    {
+                        Debug.Log(quad.transform.position - FlightGlobals.ActiveVessel.transform.position);
+                    }
+                    catch
+                    {
+                        Debug.Log("Unable to get distance to vessel");
+                    }
                 }
-                catch
+                if (quad.subdivision == FlightGlobals.currentMainBody.pqsController.maxLevel && HighLogic.LoadedScene == GameScenes.FLIGHT)
                 {
-                    Debug.Log("Unable to get distance to vessel");
+                    Debug.Log("Mask: " + LayerMask.GetMask());
+                    quad.gameObject.AddComponent<QuadMeshes>();
+                    quad.gameObject.GetComponent<QuadMeshes>().quad = quad;
+                    quad.gameObject.GetComponent<QuadMeshes>().subdivisionLevel = (int)(subdivisionLevel * ParallaxSettings.tessMult);
+                    quad.gameObject.GetComponent<QuadMeshes>().overrideDistLimit = overrideDistLimit;
+                    quad.gameObject.GetComponent<QuadMeshes>().customDistLimit = customDistLimit;
                 }
-            }
-            else if (quad.subdivision == FlightGlobals.currentMainBody.pqsController.maxLevel && HighLogic.LoadedScene == GameScenes.FLIGHT)
-            {
-                Debug.Log("Mask: " + LayerMask.GetMask());
-                quad.gameObject.AddComponent<QuadMeshes>();
-                quad.gameObject.GetComponent<QuadMeshes>().quad = quad;
-                quad.gameObject.GetComponent<QuadMeshes>().subdivisionLevel = (int)(subdivisionLevel * ParallaxSettings.tessMult);
-                quad.gameObject.GetComponent<QuadMeshes>().overrideDistLimit = overrideDistLimit;
-                quad.gameObject.GetComponent<QuadMeshes>().customDistLimit = customDistLimit;
-            }
 
-            //ADAPTIVE PARALLAX
+                //ADAPTIVE PARALLAX
 
-            if (quad)
-            {
                 double highPoint = 0;
                 double lowPoint = 0;
 
@@ -352,9 +352,7 @@ namespace PQSModExpansion
                         //quad.GetComponent<MeshRenderer>().sharedMaterial.SetTexture("_BumpMap", ParallaxShaderLoader.parallaxBodies[FlightGlobals.currentMainBody.name].ParallaxBodyMaterial.LoadTexture(ParallaxShaderLoader.parallaxBodies[FlightGlobals.currentMainBody.name].ParallaxBodyMaterial.BumpMapHigh));
                     }
                 }
-
             }
-
         }
         public override void OnQuadDestroy(PQ quad)
         {
@@ -371,9 +369,7 @@ namespace PQSModExpansion
                 {
                 }
                 Destroy(quad.gameObject.GetComponent<QuadMeshes>());    //Quad is not maxLevel anymore, remove the damn thing
-
             }
-
         }
         public Vector3 maxVertexPosition;
         public Vector3 minVertexPosition;

--- a/SubdivisionPQSMod.cs
+++ b/SubdivisionPQSMod.cs
@@ -54,7 +54,7 @@ namespace PQSModExpansion
         public GameObject newQuad;
         public GameObject collisionQuad;
         public int subdivisionLevel = 1;
-        Material transparent = new Material(Shader.Find("Unlit/Transparent"));
+        Material transparent = null;
         private float distance = 0;
         public bool overrideDistLimit = false;
         public int customDistLimit = 1000;
@@ -62,6 +62,7 @@ namespace PQSModExpansion
 
         public void Start()
         {
+            transparent = new Material(Shader.Find("Unlit/Transparent"));
             InvokeRepeating("CheckSubdivision", 1f, 1f);
         }
         public void CheckSubdivision()
@@ -72,7 +73,7 @@ namespace PQSModExpansion
                 distance = Vector3.Distance(FlightGlobals.ActiveVessel.transform.position, quad.transform.position);
                 PSystemBody Kerbin = Utility.FindBody(PSystemManager.Instance.systemPrefab.rootBody, "Kerbin");
                 double homeWorldRadiusRescaleFactor = (Kerbin.celestialBody.Radius / 600000);
-                int distLimit = (int)(120 + (FlightGlobals.currentMainBody.Radius / (450000 * (int)homeWorldRadiusRescaleFactor)) * 800);
+                int distLimit = (int)(120 + (FlightGlobals.currentMainBody.Radius / (450000 * homeWorldRadiusRescaleFactor)) * 800);
                 if (overrideDistLimit)
                 {
                     distLimit = customDistLimit;
@@ -192,15 +193,15 @@ namespace PQSModExpansion
         public bool overrideDistLimit = false;
         public int customDistLimit = 1000;
         public static bool needed = false;
-        Material fuckery = new Material(Shader.Find("Standard"));
+        //Material fuckery = new Material(Shader.Find("Standard"));
         public override void OnVertexBuild(PQS.VertexBuildData data)
         {
-            //Vector3 normal = Vector3.Normalize(LatLon.GetWorldSurfacePosition(FlightGlobals.currentMainBody.BodyFrame, FlightGlobals.currentMainBody.transform.position, FlightGlobals.currentMainBody.Radius, data.latitude, data.longitude, 0) - FlightGlobals.currentMainBody.transform.position);
+            /*//Vector3 normal = Vector3.Normalize(LatLon.GetWorldSurfacePosition(FlightGlobals.currentMainBody.BodyFrame, FlightGlobals.currentMainBody.transform.position, FlightGlobals.currentMainBody.Radius, data.latitude, data.longitude, 0) - FlightGlobals.currentMainBody.transform.position);
             try
             {
-                //data.vertHeight = (FlightGlobals.currentMainBody.Radius * 2) + 120 - data.vertHeight;
+                data.vertHeight = (FlightGlobals.currentMainBody.Radius * 2) + 120 - data.vertHeight;
             }
-            catch { }
+            catch { }*/
         }
         public override void OnQuadBuilt(PQ quad)
         {
@@ -835,21 +836,34 @@ namespace PQSModExpansion
     [KSPAddon(KSPAddon.Startup.Instantly, false)]
     public class MaterialHolder : MonoBehaviour
     {
-        public static Material standardUNKNOWN = new Material(Shader.Find("Standard"));
+        public static Material standardUNKNOWN = null;
 
-        public static Material standardLOW = new Material(Shader.Find("Standard"));
-        public static Material standardMID = new Material(Shader.Find("Standard"));
-        public static Material standardHIGH = new Material(Shader.Find("Standard"));
+        public static Material standardLOW = null;
+        public static Material standardMID = null;
+        public static Material standardHIGH = null;
 
-        public static Material standardLOWMID = new Material(Shader.Find("Standard"));
-        public static Material standardMIDHIGH = new Material(Shader.Find("Standard"));
-        public static Material standardLOWMIDHIGH = new Material(Shader.Find("Standard"));
+        public static Material standardLOWMID = null;
+        public static Material standardMIDHIGH = null;
+        public static Material standardLOWMIDHIGH = null;
 
-        public static Material standardSTEEPLOW = new Material(Shader.Find("Standard"));
-        public static Material standardSTEEPMID = new Material(Shader.Find("Standard"));
-        public static Material standardSTEEPHIGH = new Material(Shader.Find("Standard"));
+        public static Material standardSTEEPLOW = null;
+        public static Material standardSTEEPMID = null;
+        public static Material standardSTEEPHIGH = null;
         public void Start()
         {
+            standardUNKNOWN = new Material(Shader.Find("Standard"));
+
+            standardLOW = new Material(Shader.Find("Standard"));
+            standardMID = new Material(Shader.Find("Standard"));
+            standardHIGH = new Material(Shader.Find("Standard"));
+
+            standardLOWMID = new Material(Shader.Find("Standard"));
+            standardMIDHIGH = new Material(Shader.Find("Standard"));
+            standardLOWMIDHIGH = new Material(Shader.Find("Standard"));
+
+            standardSTEEPLOW = new Material(Shader.Find("Standard"));
+            standardSTEEPMID = new Material(Shader.Find("Standard"));
+            standardSTEEPHIGH = new Material(Shader.Find("Standard"));
             standardLOW.SetColor("_Color", new Color(0.9f, 0.7f, 0.7f));
             standardMID.SetColor("_Color", new Color(0.7f, 0.9f, 0.7f));
             standardHIGH.SetColor("_Color", new Color(0.7f, 0.7f, 0.9f));
@@ -1118,6 +1132,3 @@ namespace PQSModExpansion
         }
     }
 }
-
-
-


### PR DESCRIPTION
This should fix exceptions in the code.  They are caused by using find in constructor instances on monobehaviors, which is no longer permissable.  You should do the assignments as null and assign them in start, as this does.